### PR TITLE
feat: add KnowledgeCitationImageResolverService for image resolution in citations

### DIFF
--- a/apps/client/public/locales/en-US/translation.json
+++ b/apps/client/public/locales/en-US/translation.json
@@ -329,6 +329,7 @@
   "Sort A → Z": "Sort A → Z",
   "Sort Z → A": "Sort Z → A",
   "Info": "Info",
+  "Insert": "Insert",
   "Note": "Note",
   "Success": "Success",
   "Warning": "Warning",

--- a/apps/client/public/locales/zh-CN/translation.json
+++ b/apps/client/public/locales/zh-CN/translation.json
@@ -328,6 +328,7 @@
   "Sort A → Z": "按 A → Z 排序",
   "Sort Z → A": "按 Z → A 排序",
   "Info": "信息",
+  "Insert": "确定",
   "Note": "注意",
   "Success": "成功",
   "Warning": "警告",

--- a/apps/client/src/features/editor/components/date/insert-date-action.tsx
+++ b/apps/client/src/features/editor/components/date/insert-date-action.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import type { Editor } from "@tiptap/react";
+import { Button, Group, Stack } from "@mantine/core";
+import { DatePicker, DatesProvider } from "@mantine/dates";
+import { modals } from "@mantine/modals";
+import { useTranslation } from "react-i18next";
+import i18n from "@/i18n.ts";
+import { getDayjsLocale } from "@/lib/dayjs-locale.ts";
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString(i18n.language, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+interface InsertDateModalProps {
+  onConfirm: (date: Date) => void;
+}
+
+function InsertDateModal({ onConfirm }: InsertDateModalProps) {
+  const { t, i18n: instance } = useTranslation();
+  const [value, setValue] = useState<Date | null>(new Date());
+
+  return (
+    <DatesProvider settings={{ locale: getDayjsLocale(instance.language) }}>
+      <Stack gap="xs" align="center">
+        <DatePicker
+          value={value}
+          onChange={(val) => setValue(val ? new Date(val) : null)}
+          size="xs"
+        />
+        <Group justify="flex-end" gap="xs" w="100%">
+          <Button size="xs" variant="default" onClick={() => modals.closeAll()}>
+            {t("Cancel")}
+          </Button>
+          <Button
+            size="xs"
+            disabled={!value}
+            onClick={() => {
+              if (value) {
+                onConfirm(value);
+              }
+              modals.closeAll();
+            }}
+          >
+            {t("Insert")}
+          </Button>
+        </Group>
+      </Stack>
+    </DatesProvider>
+  );
+}
+
+/**
+ * Opens a compact modal with a localized date picker and inserts the selected
+ * date (formatted as plain text) into the editor at the current selection.
+ */
+export function insertDateAction(editor: Editor) {
+  modals.open({
+    title: i18n.t("Pick a date"),
+    size: "auto",
+    padding: "md",
+    children: (
+      <InsertDateModal
+        onConfirm={(date) => {
+          editor.chain().focus().insertContent(formatDate(date)).run();
+        }}
+      />
+    ),
+  });
+}

--- a/apps/client/src/features/editor/components/fixed-toolbar/groups/more-inserts-group.tsx
+++ b/apps/client/src/features/editor/components/fixed-toolbar/groups/more-inserts-group.tsx
@@ -31,6 +31,7 @@ import {
   YoutubeIcon,
 } from "@/components/icons";
 import { useTranslation } from "react-i18next";
+import { insertDateAction } from "@/features/editor/components/date/insert-date-action.tsx";
 
 interface Props {
   editor: Editor;
@@ -38,19 +39,12 @@ interface Props {
 }
 
 export const MoreInsertsGroup: FC<Props> = ({ editor, templateMode }) => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
 
   const setEmbed = (provider: string) =>
     editor.chain().focus().setEmbed({ provider }).run();
 
-  const insertDate = () => {
-    const currentDate = new Date().toLocaleDateString(i18n.language, {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-    editor.chain().focus().insertContent(currentDate).run();
-  };
+  const insertDate = () => insertDateAction(editor);
 
   return (
     <Menu shadow="md" position="bottom-start" withArrow={false} width={240}>

--- a/apps/client/src/features/editor/components/slash-menu/menu-items.ts
+++ b/apps/client/src/features/editor/components/slash-menu/menu-items.ts
@@ -43,7 +43,7 @@ import IconMermaid from "@/components/icons/icon-mermaid";
 import IconDrawio from "@/components/icons/icon-drawio";
 import { IconColumns4 } from "@/components/icons/icon-columns-4";
 import { IconColumns5 } from "@/components/icons/icon-columns-5";
-import i18n from "@/i18n.ts";
+import { insertDateAction } from "@/features/editor/components/date/insert-date-action.tsx";
 import {
   AirtableIcon,
   FigmaIcon,
@@ -457,22 +457,12 @@ const CommandGroups: SlashMenuGroupedItemsType = {
     },
     {
       title: "Date",
-      description: "Insert current date",
+      description: "Insert a date",
       searchTerms: ["date", "today"],
       icon: IconCalendar,
       command: ({ editor, range }: CommandProps) => {
-        const currentDate = new Date().toLocaleDateString(i18n.language, {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        });
-
-        editor
-          .chain()
-          .focus()
-          .deleteRange(range)
-          .insertContent(currentDate)
-          .run();
+        editor.chain().focus().deleteRange(range).run();
+        insertDateAction(editor);
       },
     },
     {

--- a/apps/client/src/lib/dayjs-locale.ts
+++ b/apps/client/src/lib/dayjs-locale.ts
@@ -1,0 +1,34 @@
+import "dayjs/locale/de";
+import "dayjs/locale/en";
+import "dayjs/locale/es";
+import "dayjs/locale/fr";
+import "dayjs/locale/it";
+import "dayjs/locale/ja";
+import "dayjs/locale/ko";
+import "dayjs/locale/nl";
+import "dayjs/locale/pt-br";
+import "dayjs/locale/ru";
+import "dayjs/locale/uk";
+import "dayjs/locale/zh-cn";
+import i18n from "@/i18n.ts";
+
+// Maps our i18n language codes to the locale names registered by dayjs.
+const DAYJS_LOCALE_MAP: Record<string, string> = {
+  "de-DE": "de",
+  "en-US": "en",
+  "es-ES": "es",
+  "fr-FR": "fr",
+  "it-IT": "it",
+  "ja-JP": "ja",
+  "ko-KR": "ko",
+  "nl-NL": "nl",
+  "pt-BR": "pt-br",
+  "ru-RU": "ru",
+  "uk-UA": "uk",
+  "zh-CN": "zh-cn",
+};
+
+export function getDayjsLocale(language?: string): string {
+  const lang = language ?? i18n.language ?? "en-US";
+  return DAYJS_LOCALE_MAP[lang] ?? DAYJS_LOCALE_MAP[lang.split("-")[0]] ?? "en";
+}

--- a/apps/server/scripts/diagnose-knowledge-image-evidence.ts
+++ b/apps/server/scripts/diagnose-knowledge-image-evidence.ts
@@ -1,0 +1,393 @@
+import { NestFactory } from '@nestjs/core';
+import { KYSELY_MODULE_CONNECTION_TOKEN } from 'nestjs-kysely';
+import { KyselyDB } from '../src/database/types/kysely.types';
+import { AiKnowledgeChatService } from '../src/ee/llm-wiki/services/ai-knowledge-chat.service';
+import { chunkKnowledgeSource } from '../src/ee/llm-wiki/chunking/knowledge-structural-chunker';
+import { loadRuntimeConfiguration } from '../src/integrations/environment/consul-config.loader';
+import type { Workspace } from '../src/database/types/entity.types';
+
+type CliOptions = {
+  email: string;
+  query?: string;
+  spaceId?: string;
+  runId?: string;
+  json: boolean;
+};
+
+type TextObservation = {
+  chars: number;
+  genericAttachmentMarkerCount: number;
+  exactAttachmentMarkerCount: number;
+  containsExactAttachmentMarker: boolean;
+  snippets: string[];
+};
+
+const DEFAULT_EMAIL = 'xuhong_yao@intsig.net';
+const RUN_LOOKBACK = 30;
+const SNIPPET_RADIUS = 180;
+
+/**
+ * Read-only diagnostic for §9 step 1 of the knowledge-image retrieval plan.
+ *
+ * This script intentionally calls AiKnowledgeChatService directly instead of
+ * the controller. It therefore exercises final citationEvidence generation
+ * without writing query audit rows or touching the future image resolver.
+ */
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (!options.query) {
+    throw new Error(
+      'A real image-related query is required. Pass --query "..."; use --help for usage.',
+    );
+  }
+
+  await loadRuntimeConfiguration();
+  const { AppModule } = await import('../src/app.module');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+
+  try {
+    const db = app.get<KyselyDB>(KYSELY_MODULE_CONNECTION_TOKEN());
+    const chatService = app.get(AiKnowledgeChatService);
+    const user = await db
+      .selectFrom('users')
+      .selectAll()
+      .where('email', 'ilike', options.email)
+      .where('deletedAt', 'is', null)
+      .orderBy('updatedAt', 'desc')
+      .executeTakeFirst();
+    if (!user?.workspaceId) {
+      throw new Error(`Active user with workspace not found: ${options.email}`);
+    }
+
+    const workspace = await db
+      .selectFrom('workspaces')
+      .selectAll()
+      .where('id', '=', user.workspaceId)
+      .where('deletedAt', 'is', null)
+      .executeTakeFirst();
+    if (!workspace) throw new Error(`Workspace not found: ${user.workspaceId}`);
+
+    const runAndImage = await findSampleRunAndImage(db, {
+      workspaceId: workspace.id,
+      spaceId: options.spaceId,
+      runId: options.runId,
+    });
+    if (!runAndImage) {
+      throw new Error(
+        'No recent succeeded/partial compile run with a succeeded image was found.',
+      );
+    }
+
+    const page = await db
+      .selectFrom('pages')
+      .select(['id', 'title', 'textContent'])
+      .where('id', '=', runAndImage.image.sourcePageId)
+      .executeTakeFirst();
+    if (!page) throw new Error(`Page not found: ${runAndImage.image.sourcePageId}`);
+
+    const source = await db
+      .selectFrom('knowledgeSources')
+      .selectAll()
+      .where('workspaceId', '=', workspace.id)
+      .where('sourcePageId', '=', page.id)
+      .where('sourceSpaceId', '=', runAndImage.run.spaceId)
+      .where('staleAt', 'is', null)
+      .where('deletedAt', 'is', null)
+      .orderBy('updatedAt', 'desc')
+      .orderBy('createdAt', 'desc')
+      .executeTakeFirst();
+
+    const storedChunks = source
+      ? await db
+          .selectFrom('knowledgeSourceChunks')
+          .select(['id', 'text', 'sourceRange', 'quoteHash'])
+          .where('workspaceId', '=', workspace.id)
+          .where('sourceId', '=', source.id)
+          .orderBy('id', 'asc')
+          .execute()
+      : [];
+
+    const fallbackText = source?.extractedText ?? page.textContent ?? '';
+    const fallbackChunks = chunkKnowledgeSource({
+      pageTitle: page.title,
+      text: fallbackText,
+    }).flatMap((parent) => parent.children);
+
+    const finalResult = await chatService.chat({
+      workspaceId: workspace.id,
+      userId: user.id,
+      query: options.query,
+      spaceIds: [runAndImage.run.spaceId],
+      workspace: workspace as Workspace,
+      // Do not print streamed answer tokens; this is an evidence diagnostic.
+      onToken: () => undefined,
+    });
+
+    const finalEvidence = finalResult.citationEvidence
+      .filter((citation) => citation.sourcePageId === page.id)
+      .map((citation) => ({
+        sourcePageId: citation.sourcePageId,
+        title: citation.title,
+        excerpts: citation.excerpts.map((excerpt) => ({
+          sourceRange: excerpt.sourceRange,
+          quoteHash: excerpt.quoteHash,
+          text: excerpt.text,
+          observation: observeText(excerpt.text, runAndImage.image.attachmentId),
+        })),
+      }));
+
+    const report = {
+      status: 'completed',
+      conclusion: summarizeConclusion({
+        source: observeText(source?.extractedText ?? '', runAndImage.image.attachmentId),
+        storedChunks: storedChunks.map((chunk) =>
+          observeText(chunk.text, runAndImage.image.attachmentId),
+        ),
+        fallback: observeText(fallbackText, runAndImage.image.attachmentId),
+        pageText: observeText(page.textContent ?? '', runAndImage.image.attachmentId),
+        finalEvidence,
+      }),
+      sample: {
+        workspaceId: workspace.id,
+        workspaceName: workspace.name,
+        spaceId: runAndImage.run.spaceId,
+        spaceName: runAndImage.spaceName,
+        runId: runAndImage.run.id,
+        runStatus: runAndImage.run.status,
+        knowledgeGeneration: runAndImage.run.knowledgeGeneration,
+        finishedAt: runAndImage.run.finishedAt,
+        sourcePageId: page.id,
+        pageTitle: page.title,
+        attachmentId: runAndImage.image.attachmentId,
+        imageStatus: runAndImage.image.status,
+        extractionId: runAndImage.image.extractionId,
+        altText: runAndImage.image.altText,
+        extraction: runAndImage.extraction,
+      },
+      query: {
+        text: options.query,
+        answerMode: finalResult.answerMode,
+        citationCount: finalResult.citations.length,
+        matchingCitationEvidenceCount: finalEvidence.length,
+      },
+      observations: {
+        enrichmentSourceText: {
+          sourceId: source?.id ?? null,
+          sourceVersion: source?.sourceVersion ?? null,
+          contentHash: source?.contentHash ?? null,
+          ...observeText(source?.extractedText ?? '', runAndImage.image.attachmentId),
+        },
+        persistedSourceChunks: {
+          chunkCount: storedChunks.length,
+          chunksWithExactMarker: storedChunks.filter((chunk) =>
+            hasExactAttachmentMarker(chunk.text, runAndImage.image.attachmentId),
+          ).length,
+          chunks: storedChunks.map((chunk) => ({
+            id: chunk.id,
+            sourceRange: chunk.sourceRange,
+            quoteHash: chunk.quoteHash,
+            ...observeText(chunk.text, runAndImage.image.attachmentId),
+          })),
+        },
+        pageTextFallback: {
+          rawPageText: observeText(page.textContent ?? '', runAndImage.image.attachmentId),
+          resolverFallbackText: {
+            sourceUsed: source?.extractedText ? 'knowledgeSources.extractedText' : 'pages.textContent',
+            ...observeText(fallbackText, runAndImage.image.attachmentId),
+          },
+          generatedFallbackChunkCount: fallbackChunks.length,
+          generatedFallbackChunksWithExactMarker: fallbackChunks.filter((chunk) =>
+            hasExactAttachmentMarker(chunk.text, runAndImage.image.attachmentId),
+          ).length,
+        },
+        finalCitationEvidence: finalEvidence,
+      },
+    };
+
+    const output = JSON.stringify(report, null, 2);
+    if (options.json) {
+      console.log(output);
+    } else {
+      console.log(output);
+      console.error('\n判定：' + report.conclusion.summary);
+    }
+  } finally {
+    await app.close();
+  }
+}
+
+async function findSampleRunAndImage(
+  db: KyselyDB,
+  input: { workspaceId: string; spaceId?: string; runId?: string },
+) {
+  const runs = await db
+    .selectFrom('knowledgeSpaceCompileRuns as run')
+    .innerJoin('spaces as space', 'space.id', 'run.spaceId')
+    .select([
+      'run.id',
+      'run.spaceId',
+      'run.status',
+      'run.knowledgeGeneration',
+      'run.finishedAt',
+      'space.name as spaceName',
+    ])
+    .where('run.workspaceId', '=', input.workspaceId)
+    .where('run.status', 'in', ['succeeded', 'partial'])
+    .where('run.finishedAt', 'is not', null)
+    .$if(Boolean(input.spaceId), (query) =>
+      query.where('run.spaceId', '=', input.spaceId!),
+    )
+    .$if(Boolean(input.runId), (query) => query.where('run.id', '=', input.runId!))
+    .orderBy('run.finishedAt', 'desc')
+    .orderBy('run.updatedAt', 'desc')
+    .limit(RUN_LOOKBACK)
+    .execute();
+
+  for (const run of runs) {
+    const image = await db
+      .selectFrom('knowledgeSpaceCompileRunImages as image')
+      .innerJoin(
+        'knowledgeSpaceCompileRunPages as page',
+        'page.id',
+        'image.runPageId',
+      )
+      .leftJoin(
+        'knowledgeImageExtractions as extraction',
+        'extraction.id',
+        'image.extractionId',
+      )
+      .select([
+        'image.sourcePageId',
+        'image.attachmentId',
+        'image.altText',
+        'image.extractionId',
+        'image.status',
+        'extraction.caption',
+        'extraction.ocrText',
+      ])
+      .where('image.runId', '=', run.id)
+      .where('image.status', '=', 'succeeded')
+      .orderBy('image.sourcePageId', 'asc')
+      .orderBy('image.imageOrdinal', 'asc')
+      .executeTakeFirst();
+    if (image) {
+      return {
+        run,
+        spaceName: run.spaceName,
+        image,
+        extraction: {
+          caption: image.caption,
+          ocrText: image.ocrText,
+        },
+      };
+    }
+  }
+  return undefined;
+}
+
+function observeText(text: string, attachmentId: string): TextObservation {
+  const genericMatches = text.match(/附件\s*ID\s*[:：]/gi) ?? [];
+  const exactMatches = text.match(
+    new RegExp(`附件\\s*ID\\s*[:：]\\s*${escapeRegExp(attachmentId)}`, 'gi'),
+  ) ?? [];
+  const snippets: string[] = [];
+  let searchFrom = 0;
+  while (searchFrom < text.length && snippets.length < 5) {
+    const markerIndex = text.indexOf('附件', searchFrom);
+    if (markerIndex < 0) break;
+    snippets.push(
+      text.slice(
+        Math.max(0, markerIndex - SNIPPET_RADIUS),
+        Math.min(text.length, markerIndex + SNIPPET_RADIUS),
+      ),
+    );
+    searchFrom = markerIndex + 2;
+  }
+  return {
+    chars: text.length,
+    genericAttachmentMarkerCount: genericMatches.length,
+    exactAttachmentMarkerCount: exactMatches.length,
+    containsExactAttachmentMarker: exactMatches.length > 0,
+    snippets,
+  };
+}
+
+function hasExactAttachmentMarker(text: string, attachmentId: string): boolean {
+  return observeText(text, attachmentId).containsExactAttachmentMarker;
+}
+
+function summarizeConclusion(input: {
+  source: TextObservation;
+  storedChunks: TextObservation[];
+  fallback: TextObservation;
+  pageText: TextObservation;
+  finalEvidence: Array<{
+    excerpts: Array<{ observation: TextObservation }>;
+  }>;
+}) {
+  const storedChunkHit = input.storedChunks.some(
+    (observation) => observation.containsExactAttachmentMarker,
+  );
+  const evidenceHit = input.finalEvidence.some((citation) =>
+    citation.excerpts.some((excerpt) => excerpt.observation.containsExactAttachmentMarker),
+  );
+  const stableAcrossAvailablePoints =
+    input.source.containsExactAttachmentMarker &&
+    (input.storedChunks.length === 0 || storedChunkHit) &&
+    input.fallback.containsExactAttachmentMarker &&
+    evidenceHit;
+  const summary = stableAcrossAvailablePoints
+    ? '附件 ID 在 source、持久化 chunks、resolver fallback 文本和最终 citationEvidence 中均保留；Evidence 强关联可以作为主路径。'
+    : evidenceHit
+      ? '最终 citationEvidence 保留附件 ID，Evidence 强关联在本样本可用，但至少一个中间观察点未保留；需扩大样本后再确认“稳定”。'
+      : '最终 citationEvidence 未保留附件 ID；本样本不能依赖 Evidence 强关联，后续应以 run image 弱关联为主。';
+  return {
+    evidenceMarkerFound: evidenceHit,
+    sourceMarkerFound: input.source.containsExactAttachmentMarker,
+    storedChunksMarkerFound: storedChunkHit,
+    fallbackMarkerFound: input.fallback.containsExactAttachmentMarker,
+    rawPageTextMarkerFound: input.pageText.containsExactAttachmentMarker,
+    stableAcrossAvailablePoints,
+    summary,
+  };
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.log(`Usage: pnpm --filter server exec tsx scripts/diagnose-knowledge-image-evidence.ts [options]
+
+Required:
+  --query <text>       Real image-related query to run through AiKnowledgeChatService
+
+Optional:
+  --email <email>      Active user used for workspace lookup (default: ${DEFAULT_EMAIL})
+  --space-id <uuid>    Restrict sample selection to one space
+  --run-id <uuid>      Inspect one compile run instead of the latest matching run
+  --json               Emit JSON only
+`);
+    process.exit(0);
+  }
+
+  const value = (name: string): string | undefined => {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] : undefined;
+  };
+  return {
+    email: value('--email') ?? DEFAULT_EMAIL,
+    query: value('--query'),
+    spaceId: value('--space-id'),
+    runId: value('--run-id'),
+    json: argv.includes('--json'),
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : error);
+  process.exitCode = 1;
+});

--- a/apps/server/src/database/repos/llm-wiki/knowledge-citation-image.repo.ts
+++ b/apps/server/src/database/repos/llm-wiki/knowledge-citation-image.repo.ts
@@ -1,0 +1,243 @@
+import { Injectable } from '@nestjs/common';
+import { InjectKysely } from 'nestjs-kysely';
+import { KyselyDB } from '@akasha/db/types/kysely.types';
+
+/**
+ * Weak-association candidate image drawn from the current published compile run
+ * of the page. Metadata (fileName/mimeType/altText) reflects the run image
+ * snapshot; the resolver must still validate the current attachment separately.
+ */
+export type RunImageCandidate = {
+  sourcePageId: string;
+  attachmentId: string;
+  altText: string | null;
+  imageOrdinal: number;
+  extractionId: string | null;
+  fileName: string;
+  mimeType: string;
+};
+
+type RunImageRow = RunImageCandidate & {
+  runId: string;
+  runFinishedAt: Date | null;
+  runUpdatedAt: Date;
+};
+
+@Injectable()
+export class KnowledgeCitationImageRepo {
+  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+
+  /**
+   * Returns the weak-association candidate pool for each page: the images of the
+   * single most recent published run that exactly matches the page's current
+   * active source. See design §4.1 "当前发布 run 的定位规则".
+   *
+   * Selection rules:
+   * - Current active source per page from `knowledgeSources`
+   *   (staleAt/deletedAt null), matched against the space's current
+   *   `knowledgeGeneration`.
+   * - Run page must match the source version + content hash and be fully
+   *   succeeded (`status` and `mergeStatus`).
+   * - Run must belong to the source's space + current generation and be in a
+   *   published terminal state (`succeeded`/`partial`); images must be
+   *   `succeeded`.
+   * - Per page keep only the newest matching run's images
+   *   (`finishedAt DESC NULLS LAST, updatedAt DESC, id DESC`); no
+   *   cross-generation fallback. Within a run, ordered by `imageOrdinal ASC`
+   *   and deduped by `attachmentId`.
+   */
+  async findCurrentPublishedRunImages(input: {
+    workspaceId: string;
+    sourcePageIds: string[];
+  }): Promise<RunImageCandidate[]> {
+    if (input.sourcePageIds.length === 0) return [];
+
+    const rows = (await this.db
+      .selectFrom('knowledgeSources as source')
+      .innerJoin('spaces as space', (join) =>
+        join
+          .onRef('space.id', '=', 'source.sourceSpaceId')
+          .onRef('space.workspaceId', '=', 'source.workspaceId'),
+      )
+      .innerJoin('knowledgeSpaceCompileRunPages as runPage', (join) =>
+        join
+          .onRef('runPage.sourcePageId', '=', 'source.sourcePageId')
+          .onRef('runPage.expectedSourceVersion', '=', 'source.sourceVersion')
+          .onRef(
+            'runPage.expectedSourceContentHash',
+            '=',
+            'source.contentHash',
+          )
+          .onRef('runPage.workspaceId', '=', 'source.workspaceId')
+          .on('runPage.status', '=', 'succeeded')
+          .on('runPage.mergeStatus', '=', 'succeeded'),
+      )
+      .innerJoin('knowledgeSpaceCompileRuns as run', (join) =>
+        join
+          .onRef('run.id', '=', 'runPage.runId')
+          .onRef('run.spaceId', '=', 'source.sourceSpaceId')
+          .onRef('run.knowledgeGeneration', '=', 'space.knowledgeGeneration')
+          .on('run.status', 'in', ['succeeded', 'partial']),
+      )
+      .innerJoin('knowledgeSpaceCompileRunImages as image', (join) =>
+        join
+          .onRef('image.runPageId', '=', 'runPage.id')
+          .on('image.status', '=', 'succeeded'),
+      )
+      .where('source.workspaceId', '=', input.workspaceId)
+      .where('source.sourcePageId', 'in', input.sourcePageIds)
+      .where('source.staleAt', 'is', null)
+      .where('source.deletedAt', 'is', null)
+      .select([
+        'image.sourcePageId as sourcePageId',
+        'image.attachmentId as attachmentId',
+        'image.altText as altText',
+        'image.imageOrdinal as imageOrdinal',
+        'image.extractionId as extractionId',
+        'image.fileName as fileName',
+        'image.mimeType as mimeType',
+        'run.id as runId',
+        'run.finishedAt as runFinishedAt',
+        'run.updatedAt as runUpdatedAt',
+      ])
+      .execute()) as RunImageRow[];
+
+    return this.selectLatestRunImagesPerPage(rows);
+  }
+
+  /**
+   * For each page, keep only the images of the winning run
+   * (finishedAt DESC NULLS LAST, updatedAt DESC, runId DESC), ordered by
+   * imageOrdinal ASC and deduped by attachmentId.
+   */
+  private selectLatestRunImagesPerPage(
+    rows: RunImageRow[],
+  ): RunImageCandidate[] {
+    const winningRunByPage = new Map<string, string>();
+    const bestRowByPage = new Map<string, RunImageRow>();
+
+    for (const row of rows) {
+      const best = bestRowByPage.get(row.sourcePageId);
+      if (best === undefined || this.isNewerRun(row, best)) {
+        bestRowByPage.set(row.sourcePageId, row);
+        winningRunByPage.set(row.sourcePageId, row.runId);
+      }
+    }
+
+    const winningRows = rows.filter(
+      (row) => winningRunByPage.get(row.sourcePageId) === row.runId,
+    );
+
+    winningRows.sort((a, b) => {
+      if (a.sourcePageId !== b.sourcePageId) {
+        return a.sourcePageId < b.sourcePageId ? -1 : 1;
+      }
+      return a.imageOrdinal - b.imageOrdinal;
+    });
+
+    const seen = new Set<string>();
+    const result: RunImageCandidate[] = [];
+    for (const row of winningRows) {
+      const dedupeKey = `${row.sourcePageId}${row.attachmentId}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      result.push({
+        sourcePageId: row.sourcePageId,
+        attachmentId: row.attachmentId,
+        altText: row.altText,
+        imageOrdinal: row.imageOrdinal,
+        extractionId: row.extractionId,
+        fileName: row.fileName,
+        mimeType: row.mimeType,
+      });
+    }
+    return result;
+  }
+
+  /** finishedAt DESC NULLS LAST, then updatedAt DESC, then runId DESC. */
+  private isNewerRun(candidate: RunImageRow, current: RunImageRow): boolean {
+    const candidateFinished = candidate.runFinishedAt?.getTime() ?? null;
+    const currentFinished = current.runFinishedAt?.getTime() ?? null;
+    if (candidateFinished !== currentFinished) {
+      // NULLS LAST: a non-null finishedAt outranks a null one.
+      if (candidateFinished === null) return false;
+      if (currentFinished === null) return true;
+      return candidateFinished > currentFinished;
+    }
+
+    const candidateUpdated = candidate.runUpdatedAt.getTime();
+    const currentUpdated = current.runUpdatedAt.getTime();
+    if (candidateUpdated !== currentUpdated) {
+      return candidateUpdated > currentUpdated;
+    }
+
+    return candidate.runId > current.runId;
+  }
+
+  /**
+   * Batch-loads captions for citation images, returning `attachmentId -> caption`.
+   *
+   * - Primary hit: by `extractionId` (weak-association path, exact same-batch
+   *   record).
+   * - Fallback: for strong-association attachments without an `extractionId`,
+   *   look up the latest `ready` extraction by `attachmentId`.
+   * - `extractionId` hits win over `attachmentId` fallbacks for the same
+   *   attachment; empty/blank captions are omitted from the map.
+   */
+  async findExtractionCaptions(input: {
+    workspaceId: string;
+    extractionIds: string[];
+    attachmentIds: string[];
+  }): Promise<Map<string, string>> {
+    const captions = new Map<string, string>();
+
+    const extractionIds = [...new Set(input.extractionIds)];
+    const attachmentIds = [...new Set(input.attachmentIds)];
+    if (extractionIds.length === 0 && attachmentIds.length === 0) {
+      return captions;
+    }
+
+    // Primary: exact extractionId hits, mapped back to their attachmentId.
+    if (extractionIds.length > 0) {
+      const rows = await this.db
+        .selectFrom('knowledgeImageExtractions')
+        .select(['id', 'attachmentId', 'caption'])
+        .where('workspaceId', '=', input.workspaceId)
+        .where('id', 'in', extractionIds)
+        .where('status', '=', 'ready')
+        .execute();
+
+      for (const row of rows) {
+        const caption = row.caption?.trim();
+        if (caption) captions.set(row.attachmentId, caption);
+      }
+    }
+
+    // Fallback: latest ready extraction per attachmentId, only for attachments
+    // not already resolved via an extractionId hit.
+    const pendingAttachmentIds = attachmentIds.filter(
+      (attachmentId) => !captions.has(attachmentId),
+    );
+    if (pendingAttachmentIds.length > 0) {
+      const rows = await this.db
+        .selectFrom('knowledgeImageExtractions')
+        .select(['attachmentId', 'caption'])
+        .distinctOn('attachmentId')
+        .where('workspaceId', '=', input.workspaceId)
+        .where('attachmentId', 'in', pendingAttachmentIds)
+        .where('status', '=', 'ready')
+        .orderBy('attachmentId', 'asc')
+        .orderBy('updatedAt', 'desc')
+        .orderBy('id', 'desc')
+        .execute();
+
+      for (const row of rows) {
+        if (captions.has(row.attachmentId)) continue;
+        const caption = row.caption?.trim();
+        if (caption) captions.set(row.attachmentId, caption);
+      }
+    }
+
+    return captions;
+  }
+}

--- a/apps/server/src/ee/llm-wiki/llm-wiki.controller.spec.ts
+++ b/apps/server/src/ee/llm-wiki/llm-wiki.controller.spec.ts
@@ -12,6 +12,7 @@ import { IAuditService } from '../../integrations/audit/audit.service';
 import { QueueJob } from '../../integrations/queue/constants';
 import { KNOWLEDGE_COMPLETENESS_NOTICE } from './services/knowledge-retrieval.service';
 import { AiKnowledgeChatService } from './services/ai-knowledge-chat.service';
+import { KnowledgeCitationImageResolverService } from './services/knowledge-citation-image-resolver.service';
 import { KnowledgeImportService } from './services/knowledge-import.service';
 import { LlmWikiController } from './llm-wiki.controller';
 import { KnowledgeDiagnosticsService } from './services/knowledge-diagnostics.service';
@@ -95,7 +96,9 @@ describe('LlmWikiController', () => {
       ),
     ).resolves.toEqual({
       answer: 'Use Kafka for async events.',
-      citations: [{ sourcePageId: 'page-1', title: 'Kafka', url: '/p/page-1' }],
+      citations: [
+        { sourcePageId: 'page-1', title: 'Kafka', url: '/p/page-1', images: [] },
+      ],
       completenessNotice: KNOWLEDGE_COMPLETENESS_NOTICE,
     });
 
@@ -1557,6 +1560,7 @@ function createController(
     chatService?: Partial<AiKnowledgeChatService>;
     auditService?: Partial<IAuditService>;
     importService?: Partial<KnowledgeImportService>;
+    citationImageResolver?: Partial<KnowledgeCitationImageResolverService>;
     diagnosticsService?: Partial<KnowledgeDiagnosticsService>;
     graphService?: Partial<KnowledgeGraphService>;
     queryAuditRepo?: Partial<KnowledgeQueryAuditRepo>;
@@ -1577,6 +1581,13 @@ function createController(
       chat: jest.fn(),
       ...overrides.chatService,
     } as unknown as AiKnowledgeChatService,
+    {
+      resolveImagesForCitations: jest.fn(
+        async ({ citations }: { citations: Array<Record<string, unknown>> }) =>
+          citations.map((citation) => ({ ...citation, images: [] })),
+      ),
+      ...overrides.citationImageResolver,
+    } as unknown as KnowledgeCitationImageResolverService,
     {
       log: jest.fn(),
       ...overrides.auditService,

--- a/apps/server/src/ee/llm-wiki/llm-wiki.controller.ts
+++ b/apps/server/src/ee/llm-wiki/llm-wiki.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   HttpStatus,
   Inject,
+  Logger,
   NotFoundException,
   Param,
   ParseUUIDPipe,
@@ -60,7 +61,12 @@ import { KnowledgeSpaceOperationDto } from './dto/knowledge-space-operation.dto'
 import { QueryKnowledgeDto } from './dto/query-knowledge.dto';
 import { KnowledgeQueryType } from './dto/query-knowledge.dto';
 import { CitationPageDto } from './dto/citation-page.dto';
-import { AiKnowledgeChatService } from './services/ai-knowledge-chat.service';
+import {
+  AiKnowledgeChatService,
+  AiKnowledgeChatResult,
+} from './services/ai-knowledge-chat.service';
+import { KnowledgeCitationImageResolverService } from './services/knowledge-citation-image-resolver.service';
+import { KnowledgeQueryCitation } from './services/knowledge-context-pack.service';
 import { KnowledgeDiagnosticsService } from './services/knowledge-diagnostics.service';
 import { KnowledgeGraphService } from './services/knowledge-graph.service';
 import { KnowledgeImportService } from './services/knowledge-import.service';
@@ -83,8 +89,11 @@ import { getApiKeyAccess } from '../../common/auth/api-key-access';
 @UseGuards(JwtAuthGuard)
 @Controller('llm-wiki')
 export class LlmWikiController {
+  private readonly logger = new Logger(LlmWikiController.name);
+
   constructor(
     private readonly chatService: AiKnowledgeChatService,
+    private readonly citationImageResolver: KnowledgeCitationImageResolverService,
     @Inject(AUDIT_SERVICE) private readonly auditService: IAuditService,
     private readonly importService: KnowledgeImportService,
     private readonly diagnosticsService: KnowledgeDiagnosticsService,
@@ -212,7 +221,44 @@ export class LlmWikiController {
       },
     });
 
-    return response;
+    // Image enrichment is a non-critical add-on: it must never change the
+    // availability of the answer text or the base citations. On any resolver
+    // failure we degrade every citation to `images: []` and still return the
+    // original response (§4.3 整体 fail-open 边界).
+    const citationsWithImages = await this.resolveCitationImages({
+      workspaceId: workspace.id,
+      answer: response.answer,
+      citations: response.citations,
+      citationEvidence: response.citationEvidence,
+    });
+
+    return { ...response, citations: citationsWithImages };
+  }
+
+  private async resolveCitationImages(input: {
+    workspaceId: string;
+    answer: string;
+    citations: AiKnowledgeChatResult['citations'];
+    citationEvidence: AiKnowledgeChatResult['citationEvidence'];
+  }): Promise<KnowledgeQueryCitation[]> {
+    const emptyImages = (): KnowledgeQueryCitation[] =>
+      input.citations.map((citation) => ({ ...citation, images: [] }));
+
+    try {
+      return await this.citationImageResolver.resolveImagesForCitations({
+        workspaceId: input.workspaceId,
+        citations: input.citations,
+        citationEvidence: input.citationEvidence,
+        answerText: input.answer,
+      });
+    } catch (err) {
+      this.logger.error(
+        `Citation image resolution failed for workspace ${input.workspaceId}; ` +
+          `degrading ${input.citations.length} citation(s) to images: []`,
+        err instanceof Error ? err.stack : undefined,
+      );
+      return emptyImages();
+    }
   }
 
   @HttpCode(HttpStatus.OK)

--- a/apps/server/src/ee/llm-wiki/llm-wiki.module.ts
+++ b/apps/server/src/ee/llm-wiki/llm-wiki.module.ts
@@ -14,6 +14,8 @@ import { KnowledgeCitationResolverService } from './services/knowledge-citation-
 import { KnowledgeDiagnosticsService } from './services/knowledge-diagnostics.service';
 import { KnowledgeGraphService } from './services/knowledge-graph.service';
 import { AiKnowledgeChatService } from './services/ai-knowledge-chat.service';
+import { KnowledgeCitationImageResolverService } from './services/knowledge-citation-image-resolver.service';
+import { KnowledgeCitationImageRepo } from '../../database/repos/llm-wiki/knowledge-citation-image.repo';
 import { ConfiguredKnowledgeAnswerProvider } from './services/knowledge-answer-provider.service';
 import { KnowledgeTextProcessor } from './processors/knowledge-text.processor';
 import { KnowledgeImageProcessor } from './processors/knowledge-image.processor';
@@ -49,9 +51,16 @@ import { KnowledgeImageReaperService } from './services/knowledge-image-reaper.s
 import { KnowledgeQualityService } from './services/knowledge-quality.service';
 import { AiModelConfigModule } from './services/ai-model-config.module';
 import { ApiKeyModule } from '../api-key/api-key.module';
+import { TokenModule } from '../../core/auth/token.module';
 
 @Module({
-  imports: [NoopAuditModule, AiModelConfigModule, ReviewModule, ApiKeyModule],
+  imports: [
+    NoopAuditModule,
+    AiModelConfigModule,
+    ReviewModule,
+    ApiKeyModule,
+    TokenModule,
+  ],
   controllers: [LlmWikiController],
   providers: [
     SpaceAuthorizationService,
@@ -69,6 +78,8 @@ import { ApiKeyModule } from '../api-key/api-key.module';
     KnowledgeQualityService,
     KnowledgeGraphService,
     AiKnowledgeChatService,
+    KnowledgeCitationImageResolverService,
+    KnowledgeCitationImageRepo,
     ConfiguredKnowledgeEmbeddingProvider,
     KnowledgeVectorIndexService,
     ConfiguredKnowledgeAnswerProvider,

--- a/apps/server/src/ee/llm-wiki/services/knowledge-citation-image-resolver.service.spec.ts
+++ b/apps/server/src/ee/llm-wiki/services/knowledge-citation-image-resolver.service.spec.ts
@@ -1,0 +1,529 @@
+import { Attachment } from '@akasha/db/types/entity.types';
+import { AttachmentRepo } from '@akasha/db/repos/attachment/attachment.repo';
+import {
+  KnowledgeCitationImageRepo,
+  RunImageCandidate,
+} from '@akasha/db/repos/llm-wiki/knowledge-citation-image.repo';
+import { TokenService } from '../../../core/auth/services/token.service';
+import { EnvironmentService } from '../../../integrations/environment/environment.service';
+import { AttachmentType } from '../../../core/attachment/attachment.constants';
+import { KnowledgeCitationImageResolverService } from './knowledge-citation-image-resolver.service';
+import type { KnowledgeCitation } from './knowledge-context-pack.service';
+import type { AiKnowledgeCitationEvidence } from './ai-knowledge-chat.service';
+
+const APP_URL = 'https://example.com';
+const WORKSPACE = 'workspace-1';
+
+/** Deterministic 36-char lowercase uuid-shaped id matching the strong regex. */
+function uid(seed: number): string {
+  const hex = seed.toString(16).padStart(8, '0');
+  return `${hex}-0000-4000-8000-000000000000`;
+}
+
+function citation(sourcePageId: string, n = 1): KnowledgeCitation {
+  return {
+    sourcePageId,
+    title: `Title ${sourcePageId} ${n}`,
+    url: `/p/${sourcePageId}`,
+  };
+}
+
+function evidence(
+  sourcePageId: string,
+  texts: string[],
+): AiKnowledgeCitationEvidence {
+  return {
+    ...citation(sourcePageId),
+    excerpts: texts.map((text) => ({
+      text,
+      sourceRange: { startOffset: 0, endOffset: text.length },
+      quoteHash: `sha256:${text.length}`,
+    })),
+  };
+}
+
+function attachment(
+  id: string,
+  pageId: string,
+  overrides: Partial<Attachment> = {},
+): Attachment {
+  return {
+    id,
+    fileName: `${id}.png`,
+    mimeType: 'image/png',
+    type: AttachmentType.File,
+    pageId,
+    spaceId: 'space-1',
+    workspaceId: WORKSPACE,
+    deletedAt: null,
+    ...overrides,
+  } as unknown as Attachment;
+}
+
+function runImage(
+  sourcePageId: string,
+  attachmentId: string,
+  overrides: Partial<RunImageCandidate> = {},
+): RunImageCandidate {
+  return {
+    sourcePageId,
+    attachmentId,
+    altText: null,
+    imageOrdinal: 0,
+    extractionId: null,
+    fileName: `${attachmentId}.png`,
+    mimeType: 'image/png',
+    ...overrides,
+  };
+}
+
+type Mocks = {
+  citationImageRepo: {
+    findCurrentPublishedRunImages: jest.Mock;
+    findExtractionCaptions: jest.Mock;
+  };
+  attachmentRepo: { findByIds: jest.Mock };
+  tokenService: { generateAttachmentToken: jest.Mock };
+  environmentService: { getAppUrl: jest.Mock };
+};
+
+function buildService(config: {
+  runImages?: RunImageCandidate[];
+  captions?: Map<string, string>;
+  attachments?: Attachment[];
+  tokenImpl?: (attachmentId: string) => Promise<string>;
+}): { service: KnowledgeCitationImageResolverService; mocks: Mocks } {
+  const mocks: Mocks = {
+    citationImageRepo: {
+      findCurrentPublishedRunImages: jest
+        .fn()
+        .mockResolvedValue(config.runImages ?? []),
+      findExtractionCaptions: jest
+        .fn()
+        .mockResolvedValue(config.captions ?? new Map<string, string>()),
+    },
+    attachmentRepo: {
+      findByIds: jest.fn().mockResolvedValue(config.attachments ?? []),
+    },
+    tokenService: {
+      generateAttachmentToken: jest.fn(
+        async (opts: { attachmentId: string }) =>
+          config.tokenImpl
+            ? config.tokenImpl(opts.attachmentId)
+            : `tok-${opts.attachmentId}`,
+      ),
+    },
+    environmentService: { getAppUrl: jest.fn().mockReturnValue(APP_URL) },
+  };
+
+  const service = new KnowledgeCitationImageResolverService(
+    mocks.citationImageRepo as unknown as KnowledgeCitationImageRepo,
+    mocks.attachmentRepo as unknown as AttachmentRepo,
+    mocks.tokenService as unknown as TokenService,
+    mocks.environmentService as unknown as EnvironmentService,
+  );
+  return { service, mocks };
+}
+
+function publicUrl(attachmentId: string, fileName: string): string {
+  return `${APP_URL}/api/files/public/${attachmentId}/${encodeURIComponent(
+    fileName,
+  )}?jwt=tok-${attachmentId}`;
+}
+
+describe('KnowledgeCitationImageResolverService', () => {
+  it('returns [] and skips repo work when there are no citations', async () => {
+    const { service, mocks } = buildService({});
+    await expect(
+      service.resolveImagesForCitations({
+        workspaceId: WORKSPACE,
+        citations: [],
+        citationEvidence: [],
+        answerText: 'anything',
+      }),
+    ).resolves.toEqual([]);
+    expect(
+      mocks.citationImageRepo.findCurrentPublishedRunImages,
+    ).not.toHaveBeenCalled();
+  });
+
+  // 1. Strong association from evidence attachment id.
+  it('returns a strong-association image when evidence carries a valid 附件 ID', async () => {
+    const attId = uid(1);
+    const { service } = buildService({
+      attachments: [attachment(attId, 'page-1', { fileName: 'diagram.png' })],
+    });
+
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [evidence('page-1', [`见图 附件 ID: ${attId} 说明`])],
+      answerText: 'irrelevant answer',
+    });
+
+    expect(resolved.images).toEqual([
+      {
+        attachmentId: attId,
+        fileName: 'diagram.png',
+        mimeType: 'image/png',
+        url: publicUrl(attId, 'diagram.png'),
+        description: '',
+      },
+    ]);
+  });
+
+  // 2. Weak association: highest-scoring run image whose alt hits answer text.
+  it('returns the single highest-scoring weak image matching the answer text', async () => {
+    const high = uid(10);
+    const low = uid(11);
+    const { service } = buildService({
+      runImages: [
+        runImage('page-1', high, {
+          altText: 'deployment architecture',
+          imageOrdinal: 0,
+        }),
+        runImage('page-1', low, {
+          altText: 'deployment overview',
+          imageOrdinal: 1,
+          extractionId: 'ext-low',
+        }),
+      ],
+      captions: new Map([[low, 'deployment']]),
+      attachments: [
+        attachment(high, 'page-1', { fileName: 'high.png' }),
+        attachment(low, 'page-1'),
+      ],
+    });
+
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [],
+      answerText: 'Please review the deployment architecture diagram.',
+    });
+
+    expect(resolved.images).toHaveLength(1);
+    expect(resolved.images[0].attachmentId).toBe(high);
+    expect(resolved.images[0].description).toBe('deployment architecture');
+  });
+
+  // 3. A run-image attachment alone never becomes a strong association.
+  it('does not treat a run-image candidate as strong when evidence has no 附件 ID', async () => {
+    const attId = uid(20);
+    const { service } = buildService({
+      runImages: [runImage('page-1', attId, { altText: 'unrelated banner' })],
+      attachments: [attachment(attId, 'page-1')],
+    });
+
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [evidence('page-1', ['文本里没有附件标识'])],
+      answerText: 'question about pricing tiers',
+    });
+
+    // No strong (no id), and weak alt does not hit the answer -> empty.
+    expect(resolved.images).toEqual([]);
+  });
+
+  // 4. Scoring: below-threshold weak candidate is dropped; identifier bonus lifts it.
+  it('drops a weak candidate scoring below 3 and keeps one lifted by the identifier bonus', async () => {
+    // alt "value details" hits only "value" (+2); not a verbatim phrase in the
+    // match text and no identifier term -> total 2, below the threshold of 3.
+    const plain = uid(30);
+    const { service: svcPlain } = buildService({
+      runImages: [runImage('page-1', plain, { altText: 'value details' })],
+      attachments: [attachment(plain, 'page-1')],
+    });
+    const [plainResolved] = await svcPlain.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [],
+      answerText: 'the value here',
+    });
+    expect(plainResolved.images).toEqual([]);
+
+    // alt "x1a details" hits "x1a" (+2) + identifier bonus (+1, mixed alnum) = 3.
+    const ident = uid(31);
+    const { service: svcIdent } = buildService({
+      runImages: [runImage('page-1', ident, { altText: 'x1a details' })],
+      attachments: [attachment(ident, 'page-1')],
+    });
+    const [identResolved] = await svcIdent.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [],
+      answerText: 'the x1a here',
+    });
+    expect(identResolved.images).toHaveLength(1);
+    expect(identResolved.images[0].attachmentId).toBe(ident);
+  });
+
+  // 5. Only one weak image per citation (already partly covered in test 2).
+  it('keeps at most one weak image per citation', async () => {
+    const a = uid(40);
+    const b = uid(41);
+    const { service } = buildService({
+      runImages: [
+        runImage('page-1', a, { altText: 'deployment guide notes' }),
+        runImage('page-1', b, { altText: 'deployment guide steps' }),
+      ],
+      attachments: [attachment(a, 'page-1'), attachment(b, 'page-1')],
+    });
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [],
+      answerText: 'read the deployment guide steps and notes',
+    });
+    expect(resolved.images).toHaveLength(1);
+  });
+
+  // 6. Global 6-image cap + strong-first ordering across citations.
+  it('caps at 6 images globally with strong associations taking the whole budget', async () => {
+    const strongIds = Array.from({ length: 7 }, (_, i) => uid(50 + i));
+    const weakId = uid(60);
+    const evidenceText = strongIds
+      .map((id) => `附件 ID: ${id}`)
+      .join('\n');
+
+    const { service } = buildService({
+      runImages: [runImage('page-A', weakId, { altText: 'deployment guide' })],
+      attachments: [
+        ...strongIds.map((id, i) =>
+          attachment(id, 'page-B', { fileName: `s${i}.png` }),
+        ),
+        attachment(weakId, 'page-A'),
+      ],
+    });
+
+    const resolved = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-A'), citation('page-B')],
+      citationEvidence: [
+        evidence('page-A', ['weak page evidence']),
+        evidence('page-B', [evidenceText]),
+      ],
+      answerText: 'read the deployment guide',
+    });
+
+    const citationA = resolved[0];
+    const citationB = resolved[1];
+    // 6 strong from B fill the budget; weak A gets nothing.
+    expect(citationB.images).toHaveLength(6);
+    expect(citationA.images).toHaveLength(0);
+    // First 6 strong ids in evidence order (imageOrdinal falls back to first
+    // occurrence index, which is ascending along the evidence text).
+    expect(citationB.images.map((img) => img.attachmentId)).toEqual(
+      strongIds.slice(0, 6),
+    );
+  });
+
+  // 7. Same attachmentId dedupe across citations.
+  it('dedupes the same attachmentId shared across citations', async () => {
+    const shared = uid(70);
+    const { service } = buildService({
+      attachments: [attachment(shared, 'page-1')],
+    });
+
+    const resolved = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      // Both citations point at page-1 and both reference the shared id.
+      citations: [citation('page-1'), citation('page-1')],
+      citationEvidence: [evidence('page-1', [`附件 ID: ${shared}`])],
+      answerText: 'irrelevant',
+    });
+
+    const all = resolved.flatMap((c) => c.images.map((i) => i.attachmentId));
+    expect(all).toEqual([shared]);
+  });
+
+  // 8. §4.3 record validation filters.
+  it('filters strong candidates failing §4.3 record validation without dropping valid ones', async () => {
+    const missing = uid(80);
+    const deleted = uid(81);
+    const wrongType = uid(82);
+    const badMime = uid(83);
+    const wrongPage = uid(84);
+    const wrongWorkspace = uid(85);
+    const valid = uid(86);
+
+    const { service } = buildService({
+      attachments: [
+        attachment(deleted, 'page-1', { deletedAt: new Date() }),
+        attachment(wrongType, 'page-1', { type: AttachmentType.Chat }),
+        attachment(badMime, 'page-1', { mimeType: 'image/gif' }),
+        attachment(wrongPage, 'page-2'),
+        attachment(wrongWorkspace, 'page-1', { workspaceId: 'other-ws' }),
+        attachment(valid, 'page-1', { fileName: 'ok.png' }),
+        // `missing` intentionally absent from findByIds result.
+      ],
+    });
+
+    const ids = [
+      missing,
+      deleted,
+      wrongType,
+      badMime,
+      wrongPage,
+      wrongWorkspace,
+      valid,
+    ];
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [
+        evidence(
+          'page-1',
+          ids.map((id) => `附件 ID: ${id}`),
+        ),
+      ],
+      answerText: 'irrelevant',
+    });
+
+    expect(resolved.images.map((i) => i.attachmentId)).toEqual([valid]);
+  });
+
+  // 9. No candidates -> empty images array.
+  it('returns images: [] for a citation with no candidates at all', async () => {
+    const { service } = buildService({});
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [evidence('page-1', ['plain text, no ids'])],
+      answerText: 'nothing matches',
+    });
+    expect(resolved.images).toEqual([]);
+  });
+
+  // 10a. Description priority alt > caption > '' via the WEAK path, which reads
+  //      alt straight off the run candidate (unaffected by the strong-path key
+  //      bug documented in test 10c).
+  it('resolves weak-image description with alt > caption > empty precedence', async () => {
+    // alt present -> alt wins (trimmed).
+    const altWins = uid(90);
+    const { service: svcAlt } = buildService({
+      runImages: [
+        runImage('page-1', altWins, { altText: '  deployment guide  ' }),
+      ],
+      attachments: [attachment(altWins, 'page-1')],
+    });
+    const [rAlt] = await svcAlt.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [],
+      answerText: 'the deployment guide steps',
+    });
+    expect(rAlt.images[0].description).toBe('deployment guide');
+
+    // alt empty, caption present -> caption wins (trimmed). Score comes from
+    // caption term hits (deployment+guide+steps = 3).
+    const captionWins = uid(91);
+    const { service: svcCap } = buildService({
+      runImages: [
+        runImage('page-1', captionWins, {
+          altText: null,
+          extractionId: 'ext-cap',
+        }),
+      ],
+      // findExtractionCaptions returns a map keyed by attachmentId.
+      captions: new Map([[captionWins, '  deployment guide steps  ']]),
+      attachments: [attachment(captionWins, 'page-1')],
+    });
+    const [rCap] = await svcCap.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [],
+      answerText: 'the deployment guide steps',
+    });
+    expect(rCap.images[0].description).toBe('deployment guide steps');
+  });
+
+  // 10b. Strong image with neither alt nor caption -> description ''.
+  it('gives a strong image an empty description when no alt/caption is available', async () => {
+    const attId = uid(93);
+    const { service } = buildService({
+      attachments: [attachment(attId, 'page-1')],
+    });
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [evidence('page-1', [`附件 ID: ${attId}`])],
+      answerText: 'irrelevant',
+    });
+    expect(resolved.images[0].description).toBe('');
+  });
+
+  // 10c. When a strong-association attachment also exists in the current
+  //      published run, its description prefers the run image's altText over
+  //      caption (design §5 alt -> caption -> ''), keyed by pageId + attachmentId.
+  it('strong image prefers run alt over caption for its description', async () => {
+    const attId = uid(94);
+    const { service } = buildService({
+      runImages: [
+        runImage('page-1', attId, { altText: 'diagram alt', imageOrdinal: 7 }),
+      ],
+      captions: new Map([[attId, 'caption fallback']]),
+      attachments: [attachment(attId, 'page-1')],
+    });
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [evidence('page-1', [`附件 ID: ${attId}`])],
+      answerText: 'irrelevant',
+    });
+    expect(resolved.images[0].description).toBe('diagram alt');
+  });
+
+  // 11. URL format with special-character filenames encoded.
+  it('signs public URLs and encodeURIComponent-encodes special filenames', async () => {
+    const attId = uid(100);
+    const fileName = '架构 图/v2 final.png';
+    const { service } = buildService({
+      attachments: [attachment(attId, 'page-1', { fileName })],
+    });
+
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [evidence('page-1', [`附件 ID: ${attId}`])],
+      answerText: 'irrelevant',
+    });
+
+    expect(resolved.images[0].url).toBe(
+      `${APP_URL}/api/files/public/${attId}/${encodeURIComponent(
+        fileName,
+      )}?jwt=tok-${attId}`,
+    );
+    expect(resolved.images[0].url).toContain('%E6%9E%B6%E6%9E%84'); // 架构
+    expect(resolved.images[0].url).toContain('%2F'); // encoded slash
+  });
+
+  // 12. Token failure isolation.
+  it('skips only the image whose token signing rejects and keeps the rest', async () => {
+    const good = uid(110);
+    const bad = uid(111);
+    const { service } = buildService({
+      attachments: [
+        attachment(good, 'page-1', { fileName: 'good.png' }),
+        attachment(bad, 'page-1', { fileName: 'bad.png' }),
+      ],
+      tokenImpl: async (attachmentId) => {
+        if (attachmentId === bad) throw new Error('token boom');
+        return `tok-${attachmentId}`;
+      },
+    });
+
+    const [resolved] = await service.resolveImagesForCitations({
+      workspaceId: WORKSPACE,
+      citations: [citation('page-1')],
+      citationEvidence: [
+        evidence('page-1', [`附件 ID: ${good}\n附件 ID: ${bad}`]),
+      ],
+      answerText: 'irrelevant',
+    });
+
+    expect(resolved.images.map((i) => i.attachmentId)).toEqual([good]);
+  });
+});
+

--- a/apps/server/src/ee/llm-wiki/services/knowledge-citation-image-resolver.service.ts
+++ b/apps/server/src/ee/llm-wiki/services/knowledge-citation-image-resolver.service.ts
@@ -1,0 +1,492 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Attachment } from '@akasha/db/types/entity.types';
+import { AttachmentRepo } from '@akasha/db/repos/attachment/attachment.repo';
+import {
+  KnowledgeCitationImageRepo,
+  RunImageCandidate,
+} from '@akasha/db/repos/llm-wiki/knowledge-citation-image.repo';
+import { TokenService } from '../../../core/auth/services/token.service';
+import { EnvironmentService } from '../../../integrations/environment/environment.service';
+import { AttachmentType } from '../../../core/attachment/attachment.constants';
+import {
+  informativeTerms,
+  normalizeSearchText,
+} from './knowledge-text-matching.util';
+import {
+  KnowledgeCitation,
+  KnowledgeQueryCitation,
+  KnowledgeQueryCitationImage,
+} from './knowledge-context-pack.service';
+import type { AiKnowledgeCitationEvidence } from './ai-knowledge-chat.service';
+
+/** Supported image MIME types (system-wide: only png/jpeg). See design §4.3. */
+const SUPPORTED_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg']);
+/** Single-query global image cap (strong + weak). Design §4.2. */
+const MAX_IMAGES_PER_QUERY = 6;
+/** Weak-association score threshold; below this the image is not returned. */
+const MIN_WEAK_ASSOCIATION_SCORE = 3;
+/** Generalized terms that must not participate in weak scoring. Design §4.2. */
+const GENERIC_MATCH_TERMS = new Set(['图片', '截图', '示意', '意图']);
+/** Extracts `附件 ID: {uuid}` from evidence text. Design §4.1 strong path. */
+const ATTACHMENT_ID_PATTERN = /附件\s*ID:\s*([0-9a-fA-F-]{36})/g;
+
+const ASSOCIATION_STRONG = 0;
+const ASSOCIATION_WEAK = 1;
+
+type SelectedImage = {
+  citationIndex: number;
+  sourcePageId: string;
+  attachmentId: string;
+  attachment: Attachment;
+  associationType: typeof ASSOCIATION_STRONG | typeof ASSOCIATION_WEAK;
+  score: number;
+  imageOrdinal: number;
+  description: string;
+};
+
+@Injectable()
+export class KnowledgeCitationImageResolverService {
+  private readonly logger = new Logger(
+    KnowledgeCitationImageResolverService.name,
+  );
+
+  constructor(
+    private readonly citationImageRepo: KnowledgeCitationImageRepo,
+    private readonly attachmentRepo: AttachmentRepo,
+    private readonly tokenService: TokenService,
+    private readonly environmentService: EnvironmentService,
+  ) {}
+
+  /**
+   * Resolves query-API images for each final citation. Strong association comes
+   * only from the Evidence path (regex over `citationEvidence[].excerpts[].text`);
+   * weak association scores the current published run-image candidate pool.
+   *
+   * `answerText` is required (added per design §4.2: weak match text =
+   * evidence + final answer). The base method signature carries no answer text,
+   * so it is threaded through here for the controller to supply.
+   *
+   * Batch-query failures propagate to the caller (controller wraps the overall
+   * fail-open boundary, §4.3). Per-image validation and token failures are
+   * isolated so a single bad image never fails the whole method.
+   */
+  async resolveImagesForCitations(input: {
+    workspaceId: string;
+    citations: KnowledgeCitation[];
+    citationEvidence: AiKnowledgeCitationEvidence[];
+    answerText: string;
+  }): Promise<KnowledgeQueryCitation[]> {
+    const { workspaceId, citations, citationEvidence, answerText } = input;
+
+    if (citations.length === 0) return [];
+
+    // evidence text per citation = concatenated excerpts of the citation whose
+    // sourcePageId matches (design §3.3 / method contract).
+    const evidenceTextByPage = this.buildEvidenceTextByPage(citationEvidence);
+
+    // 1. Strong association: attachmentId(s) extracted from the citation's own
+    //    evidence text, with first-occurrence index for later ordering.
+    const strongByCitation = citations.map((citation) =>
+      this.extractStrongAttachmentIds(
+        evidenceTextByPage.get(citation.sourcePageId) ?? '',
+      ),
+    );
+
+    // 2. Weak candidate pool: current published run images for all citation pages.
+    const sourcePageIds = [...new Set(citations.map((c) => c.sourcePageId))];
+    const runImages = await this.citationImageRepo.findCurrentPublishedRunImages(
+      { workspaceId, sourcePageIds },
+    );
+    const runImagesByPage = new Map<string, RunImageCandidate[]>();
+    for (const image of runImages) {
+      const list = runImagesByPage.get(image.sourcePageId) ?? [];
+      list.push(image);
+      runImagesByPage.set(image.sourcePageId, list);
+    }
+    // alt lookup for strong-association description (design §5): pageId+attId.
+    const runAltByPageAttachment = new Map<string, string | null>();
+    const runOrdinalByPageAttachment = new Map<string, number>();
+    for (const image of runImages) {
+      const key = `${image.sourcePageId} ${image.attachmentId}`;
+      runAltByPageAttachment.set(key, image.altText);
+      runOrdinalByPageAttachment.set(key, image.imageOrdinal);
+    }
+
+    // 3. Collect all candidate attachmentIds (strong + weak) and batch-load.
+    const candidateAttachmentIds = new Set<string>();
+    for (const ids of strongByCitation) {
+      for (const id of ids.keys()) candidateAttachmentIds.add(id);
+    }
+    for (const image of runImages) {
+      candidateAttachmentIds.add(image.attachmentId);
+    }
+    const attachments = await this.attachmentRepo.findByIds([
+      ...candidateAttachmentIds,
+    ]);
+    const attachmentById = new Map<string, Attachment>();
+    for (const attachment of attachments) {
+      attachmentById.set(attachment.id, attachment);
+    }
+
+    // 4. Load captions: extractionIds from weak candidates; attachmentIds from
+    //    strong candidates (caption reverse-lookup by attachmentId).
+    const extractionIds = runImages
+      .map((image) => image.extractionId)
+      .filter((id): id is string => id !== null);
+    const strongAttachmentIds = strongByCitation.flatMap((ids) => [
+      ...ids.keys(),
+    ]);
+    const captionByAttachment = await this.citationImageRepo.findExtractionCaptions(
+      {
+        workspaceId,
+        extractionIds,
+        attachmentIds: strongAttachmentIds,
+      },
+    );
+
+    const selected = this.selectImages({
+      citations,
+      workspaceId,
+      strongByCitation,
+      runImagesByPage,
+      attachmentById,
+      captionByAttachment,
+      runAltByPageAttachment,
+      runOrdinalByPageAttachment,
+      answerText,
+      evidenceTextByPage,
+    });
+
+    return this.assembleCitations({ citations, workspaceId, selected });
+  }
+
+  private buildEvidenceTextByPage(
+    citationEvidence: AiKnowledgeCitationEvidence[],
+  ): Map<string, string> {
+    const byPage = new Map<string, string[]>();
+    for (const evidence of citationEvidence) {
+      const texts = byPage.get(evidence.sourcePageId) ?? [];
+      for (const excerpt of evidence.excerpts) {
+        texts.push(excerpt.text);
+      }
+      byPage.set(evidence.sourcePageId, texts);
+    }
+    const joined = new Map<string, string>();
+    for (const [pageId, texts] of byPage) {
+      joined.set(pageId, texts.join('\n'));
+    }
+    return joined;
+  }
+
+  /**
+   * Strong association (Evidence path only): extract `附件 ID: {uuid}` from the
+   * citation's evidence text. Returns attachmentId -> first-occurrence index
+   * (used as the imageOrdinal fallback ordering key when no run image exists).
+   */
+  private extractStrongAttachmentIds(text: string): Map<string, number> {
+    const ids = new Map<string, number>();
+    if (!text) return ids;
+    ATTACHMENT_ID_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = ATTACHMENT_ID_PATTERN.exec(text)) !== null) {
+      const attachmentId = match[1].toLowerCase();
+      if (!ids.has(attachmentId)) {
+        ids.set(attachmentId, match.index);
+      }
+    }
+    return ids;
+  }
+
+  /**
+   * DB-record validation only (design §4.3): exists, not deleted, File type,
+   * supported image MIME, pageId matches citation, workspace matches. Returns
+   * the attachment when valid, otherwise null (single image skipped).
+   */
+  private validateAttachment(
+    attachment: Attachment | undefined,
+    sourcePageId: string,
+    workspaceId: string,
+  ): Attachment | null {
+    if (!attachment) return null;
+    if (attachment.deletedAt !== null) return null;
+    if (attachment.type !== AttachmentType.File) return null;
+    if (!SUPPORTED_IMAGE_MIME_TYPES.has(attachment.mimeType)) return null;
+    if (attachment.pageId !== sourcePageId) return null;
+    if (attachment.workspaceId !== workspaceId) return null;
+    return attachment;
+  }
+
+  private selectImages(args: {
+    citations: KnowledgeCitation[];
+    workspaceId: string;
+    strongByCitation: Array<Map<string, number>>;
+    runImagesByPage: Map<string, RunImageCandidate[]>;
+    attachmentById: Map<string, Attachment>;
+    captionByAttachment: Map<string, string>;
+    runAltByPageAttachment: Map<string, string | null>;
+    runOrdinalByPageAttachment: Map<string, number>;
+    answerText: string;
+    evidenceTextByPage: Map<string, string>;
+  }): SelectedImage[] {
+    const {
+      citations,
+      workspaceId,
+      strongByCitation,
+      runImagesByPage,
+      attachmentById,
+      captionByAttachment,
+      runAltByPageAttachment,
+      runOrdinalByPageAttachment,
+      answerText,
+      evidenceTextByPage,
+    } = args;
+
+    const candidates: SelectedImage[] = [];
+
+    citations.forEach((citation, citationIndex) => {
+      const pageId = citation.sourcePageId;
+      const strongIds = strongByCitation[citationIndex];
+      const strongCovered = new Set<string>();
+
+      // Strong association: all valid, in-budget images returned (§4.1).
+      for (const [attachmentId, evidenceIndex] of strongIds) {
+        const attachment = this.validateAttachment(
+          attachmentById.get(attachmentId),
+          pageId,
+          workspaceId,
+        );
+        if (!attachment) continue;
+        strongCovered.add(attachmentId);
+        const altKey = `${pageId} ${attachmentId}`;
+        const alt = runAltByPageAttachment.get(altKey) ?? null;
+        const caption = captionByAttachment.get(attachmentId) ?? '';
+        candidates.push({
+          citationIndex,
+          sourcePageId: pageId,
+          attachmentId,
+          attachment,
+          associationType: ASSOCIATION_STRONG,
+          score: Number.POSITIVE_INFINITY,
+          imageOrdinal:
+            runOrdinalByPageAttachment.get(altKey) ?? evidenceIndex,
+          description: this.resolveDescription(alt, caption),
+        });
+      }
+
+      // Weak association: score only strong-uncovered run-image candidates,
+      // keep the single highest-scoring image (>= threshold) per citation.
+      const matchText = `${answerText}\n${evidenceTextByPage.get(pageId) ?? ''}`;
+      const queryTerms = informativeTerms(matchText).filter(
+        (term) => !GENERIC_MATCH_TERMS.has(term),
+      );
+      const normalizedMatchText = this.collapseWhitespace(
+        normalizeSearchText(matchText),
+      );
+
+      let best: SelectedImage | null = null;
+      for (const runImage of runImagesByPage.get(pageId) ?? []) {
+        if (strongCovered.has(runImage.attachmentId)) continue;
+        const attachment = this.validateAttachment(
+          attachmentById.get(runImage.attachmentId),
+          pageId,
+          workspaceId,
+        );
+        if (!attachment) continue;
+
+        const caption = captionByAttachment.get(runImage.attachmentId) ?? '';
+        const score = this.scoreWeakCandidate({
+          alt: runImage.altText,
+          caption,
+          queryTerms,
+          normalizedMatchText,
+        });
+        if (score < MIN_WEAK_ASSOCIATION_SCORE) continue;
+
+        const candidate: SelectedImage = {
+          citationIndex,
+          sourcePageId: pageId,
+          attachmentId: runImage.attachmentId,
+          attachment,
+          associationType: ASSOCIATION_WEAK,
+          score,
+          imageOrdinal: runImage.imageOrdinal,
+          description: this.resolveDescription(runImage.altText, caption),
+        };
+        if (best === null || this.isBetterWeak(candidate, best)) {
+          best = candidate;
+        }
+      }
+      if (best !== null) candidates.push(best);
+    });
+
+    return this.mergeSortAndCap(candidates);
+  }
+
+  /** Higher score wins; tie-break imageOrdinal ASC then attachmentId ASC. */
+  private isBetterWeak(a: SelectedImage, b: SelectedImage): boolean {
+    if (a.score !== b.score) return a.score > b.score;
+    if (a.imageOrdinal !== b.imageOrdinal)
+      return a.imageOrdinal < b.imageOrdinal;
+    return a.attachmentId < b.attachmentId;
+  }
+
+  /**
+   * Unified sort key (§4.2): associationType (strong first) -> citationIndex ASC
+   * -> score DESC -> imageOrdinal ASC -> attachmentId ASC. Dedupe by
+   * attachmentId (first in sort order wins), then cap at 6.
+   */
+  private mergeSortAndCap(candidates: SelectedImage[]): SelectedImage[] {
+    candidates.sort((a, b) => {
+      if (a.associationType !== b.associationType)
+        return a.associationType - b.associationType;
+      if (a.citationIndex !== b.citationIndex)
+        return a.citationIndex - b.citationIndex;
+      if (a.score !== b.score) return b.score - a.score;
+      if (a.imageOrdinal !== b.imageOrdinal)
+        return a.imageOrdinal - b.imageOrdinal;
+      return a.attachmentId < b.attachmentId ? -1 : 1;
+    });
+
+    const seen = new Set<string>();
+    const deduped: SelectedImage[] = [];
+    for (const candidate of candidates) {
+      if (seen.has(candidate.attachmentId)) continue;
+      seen.add(candidate.attachmentId);
+      deduped.push(candidate);
+      if (deduped.length >= MAX_IMAGES_PER_QUERY) break;
+    }
+    return deduped;
+  }
+
+  /**
+   * Weak-association score (§4.2): alt hit = 2, caption hit = 1, OCR hit = 1;
+   * alt full phrase +3 once; alt identifier +1 once. Same field + same term
+   * counts once. Generic terms already filtered out of `queryTerms`.
+   *
+   * OCR scoring待候选池补 ocrText 后启用: RunImageCandidate carries no ocrText,
+   * so only alt (RunImageCandidate.altText) and caption participate this round.
+   */
+  private scoreWeakCandidate(args: {
+    alt: string | null;
+    caption: string;
+    queryTerms: string[];
+    normalizedMatchText: string;
+  }): number {
+    const { alt, caption, queryTerms, normalizedMatchText } = args;
+    if (queryTerms.length === 0) return 0;
+
+    let score = 0;
+    const normalizedAlt = this.collapseWhitespace(
+      normalizeSearchText(alt ?? ''),
+    );
+    const normalizedCaption = this.collapseWhitespace(
+      normalizeSearchText(caption),
+    );
+
+    // Field hits: each distinct query term counts once per field.
+    for (const term of queryTerms) {
+      if (normalizedAlt.includes(term)) score += 2;
+    }
+    for (const term of queryTerms) {
+      if (normalizedCaption.includes(term)) score += 1;
+    }
+
+    // alt full-phrase bonus (once): non-empty normalized alt appears verbatim.
+    if (normalizedAlt && normalizedMatchText.includes(normalizedAlt)) {
+      score += 3;
+    }
+
+    // alt identifier bonus (once): a hit term with _ / . : - or mixed alnum.
+    const hasIdentifierHit = queryTerms.some(
+      (term) =>
+        normalizedAlt.includes(term) &&
+        (/[_/.:-]/.test(term) ||
+          (/[a-z]/.test(term) && /[0-9]/.test(term))),
+    );
+    if (hasIdentifierHit) score += 1;
+
+    return score;
+  }
+
+  /** alt -> caption -> ''. Design §5 / §8. Never returns OCR. */
+  private resolveDescription(alt: string | null, caption: string): string {
+    const trimmedAlt = alt?.trim();
+    if (trimmedAlt) return trimmedAlt;
+    const trimmedCaption = caption.trim();
+    if (trimmedCaption) return trimmedCaption;
+    return '';
+  }
+
+  private collapseWhitespace(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+  }
+
+  /**
+   * Signs public URLs per selected image, isolated via Promise.allSettled so a
+   * single token failure only drops that image. Then groups images back onto
+   * each citation in original order (images ordered by the global sort key).
+   */
+  private async assembleCitations(args: {
+    citations: KnowledgeCitation[];
+    workspaceId: string;
+    selected: SelectedImage[];
+  }): Promise<KnowledgeQueryCitation[]> {
+    const { citations, workspaceId, selected } = args;
+
+    const settled = await Promise.allSettled(
+      selected.map((image) => this.buildImage(image, workspaceId)),
+    );
+
+    const imagesByCitation = new Map<number, KnowledgeQueryCitationImage[]>();
+    let failedTokenCount = 0;
+    settled.forEach((result, index) => {
+      if (result.status !== 'fulfilled' || result.value === null) {
+        failedTokenCount += 1;
+        return;
+      }
+      const citationIndex = selected[index].citationIndex;
+      const list = imagesByCitation.get(citationIndex) ?? [];
+      list.push(result.value);
+      imagesByCitation.set(citationIndex, list);
+    });
+
+    if (failedTokenCount > 0) {
+      this.logger.warn(
+        `image url signing skipped ${failedTokenCount} image(s) ` +
+          `[workspaceId=${workspaceId}, stage=token, selected=${selected.length}]`,
+      );
+    }
+
+    return citations.map((citation, citationIndex) => ({
+      ...citation,
+      images: imagesByCitation.get(citationIndex) ?? [],
+    }));
+  }
+
+  private async buildImage(
+    image: SelectedImage,
+    workspaceId: string,
+  ): Promise<KnowledgeQueryCitationImage | null> {
+    try {
+      const token = await this.tokenService.generateAttachmentToken({
+        attachmentId: image.attachmentId,
+        pageId: image.sourcePageId,
+        workspaceId,
+      });
+      const appUrl = this.environmentService.getAppUrl();
+      const fileName = image.attachment.fileName;
+      const url = `${appUrl}/api/files/public/${image.attachmentId}/${encodeURIComponent(
+        fileName,
+      )}?jwt=${token}`;
+      return {
+        attachmentId: image.attachmentId,
+        fileName,
+        mimeType: image.attachment.mimeType,
+        url,
+        description: image.description,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/server/src/ee/llm-wiki/services/knowledge-context-pack.service.ts
+++ b/apps/server/src/ee/llm-wiki/services/knowledge-context-pack.service.ts
@@ -14,6 +14,29 @@ export type KnowledgeCitation = {
   url: string;
 };
 
+/**
+ * Image attached to a query-API citation. Only produced at the
+ * `/api/llm-wiki/query` response boundary; never part of the shared
+ * `KnowledgeCitation` / `KnowledgeSourceWindow` / evidence types.
+ */
+export type KnowledgeQueryCitationImage = {
+  attachmentId: string;
+  fileName: string;
+  mimeType: string;
+  url: string;
+  description: string;
+};
+
+/**
+ * Citation shape returned exclusively by `/api/llm-wiki/query`. Derives from
+ * the base `KnowledgeCitation` and always carries an `images` array (possibly
+ * empty). Kept separate so adding images never leaks into `sourceWindows`,
+ * `retrievedSources` or `citationEvidence`.
+ */
+export type KnowledgeQueryCitation = KnowledgeCitation & {
+  images: KnowledgeQueryCitationImage[];
+};
+
 export type KnowledgeSourceWindow = KnowledgeCitation & {
   text: string;
   sourceRange: KnowledgeSourceRange;

--- a/apps/server/src/ee/llm-wiki/services/knowledge-retrieval-ranker.service.ts
+++ b/apps/server/src/ee/llm-wiki/services/knowledge-retrieval-ranker.service.ts
@@ -4,6 +4,7 @@ import {
   KnowledgeChunkCandidate,
   KnowledgeRetrievalSignal,
 } from '@akasha/db/repos/llm-wiki/knowledge-capsule.repo';
+import { hasInformativeTextOverlap } from './knowledge-text-matching.util';
 
 type RankableChunk = {
   chunk: KnowledgeChunk;
@@ -209,51 +210,6 @@ function candidateSignalScores(
   );
 }
 
-function hasInformativeTextOverlap(query: string, text: string): boolean {
-  const queryTerms = informativeTerms(query);
-  if (queryTerms.length === 0) return false;
-  const normalizedText = normalizeSearchText(text);
-  return queryTerms.some((term) => normalizedText.includes(term));
-}
-
-function informativeTerms(value: string): string[] {
-  const normalized = normalizeSearchText(value);
-  const asciiStopWords = new Set([
-    'and',
-    'are',
-    'for',
-    'how',
-    'the',
-    'what',
-    'when',
-    'where',
-    'which',
-    'who',
-    'why',
-  ]);
-  const ascii = (normalized.match(/[a-z0-9_./:-]{2,}/g) ?? []).filter(
-    (term) => !asciiStopWords.has(term),
-  );
-  const hanStopWords = new Set([
-    '什么',
-    '如何',
-    '多少',
-    '时候',
-    '的是',
-    '一下',
-  ]);
-  const han = (normalized.match(/[\p{Script=Han}]{2,}/gu) ?? []).flatMap(
-    (segment) =>
-      Array.from({ length: Math.max(0, segment.length - 1) }, (_, index) =>
-        segment.slice(index, index + 2),
-      ).filter((term) => !hanStopWords.has(term)),
-  );
-  return [...new Set([...ascii, ...han])];
-}
-
-function normalizeSearchText(value: string): string {
-  return value.normalize('NFKC').toLocaleLowerCase('en-US');
-}
 
 function rankSemanticCandidates(input: {
   query: string;

--- a/apps/server/src/ee/llm-wiki/services/knowledge-text-matching.util.ts
+++ b/apps/server/src/ee/llm-wiki/services/knowledge-text-matching.util.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared lexical matching helpers used by both retrieval ranking and image
+ * citation resolution. Kept in one place so image weak-association scoring uses
+ * the exact same tokenization/normalization as retrieval, avoiding drift and
+ * flaky tests.
+ */
+
+export function normalizeSearchText(value: string): string {
+  return value.normalize('NFKC').toLocaleLowerCase('en-US');
+}
+
+/**
+ * Extract informative terms from a piece of text:
+ * - ASCII runs `[a-z0-9_./:-]{2,}` (preserves UUIDs, identifiers, API paths),
+ *   minus common English stop words.
+ * - Chinese 2-grams over Han runs, minus common Chinese stop words.
+ */
+export function informativeTerms(value: string): string[] {
+  const normalized = normalizeSearchText(value);
+  const asciiStopWords = new Set([
+    'and',
+    'are',
+    'for',
+    'how',
+    'the',
+    'what',
+    'when',
+    'where',
+    'which',
+    'who',
+    'why',
+  ]);
+  const ascii = (normalized.match(/[a-z0-9_./:-]{2,}/g) ?? []).filter(
+    (term) => !asciiStopWords.has(term),
+  );
+  const hanStopWords = new Set([
+    '什么',
+    '如何',
+    '多少',
+    '时候',
+    '的是',
+    '一下',
+  ]);
+  const han = (normalized.match(/[\p{Script=Han}]{2,}/gu) ?? []).flatMap(
+    (segment) =>
+      Array.from({ length: Math.max(0, segment.length - 1) }, (_, index) =>
+        segment.slice(index, index + 2),
+      ).filter((term) => !hanStopWords.has(term)),
+  );
+  return [...new Set([...ascii, ...han])];
+}
+
+export function hasInformativeTextOverlap(query: string, text: string): boolean {
+  const queryTerms = informativeTerms(query);
+  if (queryTerms.length === 0) return false;
+  const normalizedText = normalizeSearchText(text);
+  return queryTerms.some((term) => normalizedText.includes(term));
+}


### PR DESCRIPTION
- Introduced KnowledgeCitationImageResolverService to resolve images for citations based on strong and weak associations.
- Implemented methods for extracting strong attachment IDs from citation evidence and scoring weak candidates based on their relevance to the answer text.
- Added unit tests for the new service to ensure correct functionality and edge case handling.
- Updated KnowledgeCitation and KnowledgeQueryCitation types to include image data.
- Refactored text matching utilities for shared use between retrieval ranking and image citation resolution.
- Enhanced knowledge retrieval ranker to utilize new text matching utilities.